### PR TITLE
Update sparse_matmul_op.h

### DIFF
--- a/tensorflow/core/kernels/sparse_matmul_op.h
+++ b/tensorflow/core/kernels/sparse_matmul_op.h
@@ -39,7 +39,7 @@ EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_l(const Packet& from) {
 // in the upper 16-bits of input
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_u(const Packet& from) {
-  tensorflow::uint32 tmp ;
+  tensorflow::uint32 tmp;
   if ( __BYTE_ORDER == __BIG_ENDIAN ) {
         tmp = (reinterpret_cast<const tensorflow::uint32&>(from) << 16 ) & 0xffff0000;
   } else {

--- a/tensorflow/core/kernels/sparse_matmul_op.h
+++ b/tensorflow/core/kernels/sparse_matmul_op.h
@@ -26,8 +26,12 @@ namespace internal {
 // in the lower 16-bits of input
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_l(const Packet& from) {
-  tensorflow::uint32 tmp =
-      (reinterpret_cast<const tensorflow::uint32&>(from) << 16) & 0xffff0000;
+  tensorflow::uint32 tmp;
+  if ( __BYTE_ORDER == __BIG_ENDIAN ) {
+       tmp = (reinterpret_cast<const tensorflow::uint32&>(from) ) & 0xffff0000;
+  } else {
+      tmp = (reinterpret_cast<const tensorflow::uint32&>(from) << 16) & 0xffff0000;
+  }
   return reinterpret_cast<const float&>(tmp);
 }
 
@@ -35,8 +39,12 @@ EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_l(const Packet& from) {
 // in the upper 16-bits of input
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_u(const Packet& from) {
-  tensorflow::uint32 tmp =
-      (reinterpret_cast<const tensorflow::uint32&>(from)) & 0xffff0000;
+  tensorflow::uint32 tmp ;
+  if ( __BYTE_ORDER == __BIG_ENDIAN ) {
+        tmp = (reinterpret_cast<const tensorflow::uint32&>(from) << 16 ) & 0xffff0000;
+  } else {
+        tmp = (reinterpret_cast<const tensorflow::uint32&>(from)) & 0xffff0000;
+  }
   return reinterpret_cast<const float&>(tmp);
 }
 


### PR DESCRIPTION
Adding correction for Big Endian architecture while returning the float representation of the bfloat16 value